### PR TITLE
Fix date pickers

### DIFF
--- a/lib/screens/forms/case_plan/cpt/screens/safe_cpt.dart
+++ b/lib/screens/forms/case_plan/cpt/screens/safe_cpt.dart
@@ -431,7 +431,6 @@ class _SafeCasePlanState extends State<SafeCasePlan> {
               context.read<CptProvider>().cptSafeFormData ?? CptSafeFormData();
           context.read<CptProvider>().updateCptSafeFormData(cptSafeFormData
               .copyWith(completionDate: completionDate.toIso8601String()));
-          print("The selected date was $completionDate");
         },
       ),
       const SizedBox(height: 10),

--- a/lib/screens/forms/form1a/new/form_one_a.dart
+++ b/lib/screens/forms/form1a/new/form_one_a.dart
@@ -137,6 +137,7 @@ class _FomOneAState extends State<FomOneA> {
                                   hintText: 'Select the date',
                                   selectedDateTime:
                                       form1AProvider.formData.selectedDate,
+                                  allowFutureDates: false,
                                   onDateSelected: (selectedDate) {
                                     form1AProvider
                                         .setSelectedDate(selectedDate);

--- a/lib/screens/forms/form1b/form_1B.dart
+++ b/lib/screens/forms/form1b/form_1B.dart
@@ -130,6 +130,7 @@ class _Form1BScreen extends State<Form1BScreen> {
                                 ),
                                 const SizedBox(height: 10),
                                 CustomFormsDatePicker(
+                                  allowFutureDates: false,
                                     hintText: 'Select the date',
                                     selectedDateTime:
                                         form1bProvider.formData.selectedDate,

--- a/lib/widgets/custom_forms_date_picker.dart
+++ b/lib/widgets/custom_forms_date_picker.dart
@@ -29,7 +29,7 @@ class CustomFormsDatePicker extends StatefulWidget {
   final bool allowPastDates;  // Add the flag for allowing past dates
   final bool allowFutureDates;  // Add the flag for allowing future dates
   final Function(DateTime selectedDate)
-  onDateSelected; // Define the callback function signature
+      onDateSelected; // Define the callback function signature
 
   @override
   State<CustomFormsDatePicker> createState() => _CustomDatePickerState();
@@ -67,8 +67,12 @@ class _CustomDatePickerState extends State<CustomFormsDatePicker> {
           currentDate: selectedDate,
           context: context,
           initialDate: widget.initialDate ?? DateTime.now(),
-          firstDate: widget.firstDate ?? DateTime(2012, 1, 1, 11, 59),
-          lastDate: widget.lastDate ?? DateTime(2100, 12, 31, 11, 59),
+          firstDate: widget.allowPastDates
+              ? widget.firstDate ?? DateTime(2012, 1, 1, 11, 59)
+              : DateTime.now(),
+          lastDate: widget.allowFutureDates
+              ? widget.lastDate ?? DateTime(2100, 12, 31, 11, 59)
+              : DateTime.now(),
         ).then((value) {
           if (value != null) {
             setState(() {


### PR DESCRIPTION
This pull request fixes the date pickers in the codebase. Specifically, it adds the ability to disallow future dates in the `CustomFormsDatePicker` component, and removes a print statement in the `_SafeCasePlanState` component. Additionally, it updates the `selectedDateTime` property in the `_FomOneAState` and `_Form1BScreen` components to ensure that the selected date is not in the future.