### PR TITLE
Update API URL and add new fields to SummaryDataModel

### DIFF
--- a/lib/Models/statistic_model.dart
+++ b/lib/Models/statistic_model.dart
@@ -1,23 +1,29 @@
 class SummaryDataModel {
-   int children = 0;
-   int caregivers = 0;
-   int government = 0;
-   int ngo = 0;
-   int caseRecords = 0;
-   int pendingCases = 0;
-   int orgUnits = 0;
-   int workforceMembers = 0;
-   int household = 0;
-   int childrenAll = 0; //ever register
-   OvcSummary ovcSummary = OvcSummary(
+  int children = 0;
+  int caregivers = 0;
+  int government = 0;
+  int ngo = 0;
+  int caseRecords = 0;
+  int pendingCases = 0;
+  int orgUnits = 0;
+  int workforceMembers = 0;
+  int household = 0;
+  int childrenAll = 0; //ever register
+  OvcSummary ovcSummary = OvcSummary(
       m0: 0, m1: 0, m2: 0, m3: 0, m4: 0, f0: 0, f1: 0, f2: 0, f3: 0, f4: 0);
-   List<dynamic> ovcRegs = [];
-   List<dynamic> caseRegs = [];
-   Map<String, dynamic> caseCats = {};
-   Map<String, dynamic> criteria = {};
-   String orgUnit = '';
-   int orgUnitId = 0;
-   String details = '';
+  List<dynamic> ovcRegs = [];
+  List<dynamic> caseRegs = [];
+  Map<String, dynamic> caseCats = {};
+  Map<String, dynamic> criteria = {};
+  String orgUnit = '';
+  int orgUnitId = 0;
+  String details = '';
+  int unapproved = 0;
+  int form1a, form1b = 0;
+  int cpara, cpt, clhiv = 0;
+  int unapprovedF1A, unapprovedF1B = 0;
+  int unapprovedCPR, unapprovedCPT = 0;
+  int unapprovedHRS, unapprovedHMF = 0;
 
   SummaryDataModel({
     required this.children,
@@ -38,6 +44,18 @@ class SummaryDataModel {
     required this.orgUnit,
     required this.orgUnitId,
     required this.details,
+    required this.unapproved,
+    required this.form1a,
+    required this.form1b,
+    required this.cpara,
+    required this.cpt,
+    required this.clhiv,
+    required this.unapprovedF1A,
+    required this.unapprovedF1B,
+    required this.unapprovedCPR,
+    required this.unapprovedCPT,
+    required this.unapprovedHRS,
+    required this.unapprovedHMF,
   });
 
   factory SummaryDataModel.fromJson(Map<String, dynamic> json) {
@@ -60,6 +78,18 @@ class SummaryDataModel {
       orgUnit: json['org_unit'],
       orgUnitId: json['org_unit_id'],
       details: json['details'],
+      unapproved: json['unapproved'],
+      form1a: json['form1a'],
+      form1b: json['form1b'],
+      cpara: json['cpara'],
+      cpt: json['cpt'],
+      clhiv: json['clhiv'],
+      unapprovedF1A: json['unapproved_F1A'],
+      unapprovedF1B: json['unapproved_F1B'],
+      unapprovedCPR: json['unapproved_CPR'],
+      unapprovedCPT: json['unapproved_CPT'],
+      unapprovedHRS: json['unapproved_HRS'],
+      unapprovedHMF: json['unapproved_HMF'],
     );
   }
 
@@ -83,6 +113,18 @@ class SummaryDataModel {
       'org_unit': orgUnit,
       'org_unit_id': orgUnitId,
       'details': details,
+      'unapproved': unapproved,
+      'form1a': form1a,
+      'form1b': form1b,
+      'cpara': cpara,
+      'cpt': cpt,
+      'clhiv': clhiv,
+      'unapproved_F1A': unapprovedF1A,
+      'unapproved_F1B': unapprovedF1B,
+      'unapproved_CPR': unapprovedCPR,
+      'unapproved_CPT': unapprovedCPT,
+      'unapproved_HRS': unapprovedHRS,
+      'unapproved_HMF': unapprovedHMF,
     };
   }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -302,8 +302,8 @@ List<Map<String, dynamic>> personRegistryStepper = [
   },
 ];
 
-const String cpimsApiUrl = "https://ovc.childprotection.uonbi.ac.ke/";
-// const String cpimsApiUrl = "https://dev.cpims.net/";
+// const String cpimsApiUrl = "https://ovc.childprotection.uonbi.ac.ke/";
+const String cpimsApiUrl = "https://dev.cpims.net/";
 
 const Map<String, String> headers = {"Content-Type": "application/json"};
 

--- a/lib/screens/homepage/home_page.dart
+++ b/lib/screens/homepage/home_page.dart
@@ -1,4 +1,3 @@
-
 import 'package:cpims_mobile/Models/statistic_model.dart';
 import 'package:cpims_mobile/constants.dart';
 import 'package:cpims_mobile/providers/connection_provider.dart';
@@ -8,6 +7,7 @@ import 'package:cpims_mobile/screens/homepage/provider/stats_provider.dart';
 import 'package:cpims_mobile/screens/homepage/widgets/statistics_item.dart';
 import 'package:cpims_mobile/screens/homepage/widgets/statistics_grid_item.dart';
 import 'package:cpims_mobile/screens/ovc_care/ovc_care_screen.dart';
+import 'package:cpims_mobile/screens/unapproved_records/unapproved_records_screen.dart';
 import 'package:cpims_mobile/services/form_service.dart';
 import 'package:cpims_mobile/widgets/app_bar.dart';
 import 'package:cpims_mobile/widgets/custom_button.dart';
@@ -269,60 +269,60 @@ class _HomepageState extends State<Homepage> {
                       cparaCount: formStats.cparaCount,
                       onClick: () {},
                     ),
-                    // StatisticsItem(
-                    //   title: 'UNAPPROVED RECORDS',
-                    //   icon: FontAwesomeIcons.fileCircleXmark,
-                    //   color: const Color(0xff947901),
-                    //   secondaryColor: const Color(0xff524300),
-                    //   form1ACount: 4,
-                    //   form1BCount: 3,
-                    //   cpaCount: 2,
-                    //   cparaCount: 1,
-                    //   onClick: () {
-                    //     Get.to(() => const UnapprovedRecordsScreens());
-                    //   },
-                    // ),
+                    StatisticsItem(
+                      title: 'UNAPPROVED RECORDS',
+                      icon: FontAwesomeIcons.fileCircleXmark,
+                      color: const Color(0xff947901),
+                      secondaryColor: const Color(0xff524300),
+                      form1ACount: dashData.unapprovedF1A,
+                      form1BCount: dashData.unapprovedF1B,
+                      cpaCount: dashData.unapprovedCPR,
+                      cparaCount: dashData.unapprovedCPT,
+                      onClick: () {
+                        Get.to(() => const UnapprovedRecordsScreens());
+                      },
+                    ),
                     CustomGridView(
                       crossAxisCount: 2,
                       childrenHeight: 180,
                       shrinkWrap: true,
                       physics: const NeverScrollableScrollPhysics(),
                       children: [
-                        // const StatisticsGridItem(
-                        //   title: 'FORM 1A',
-                        //   value: "10/20",
-                        //   icon: FontAwesomeIcons.fileLines,
-                        //   color: kPrimaryColor,
-                        //   secondaryColor: Color(0xff0E6668),
-                        // ),
-                        // const StatisticsGridItem(
-                        //   title: 'FORM 1B',
-                        //   value: "10/20",
-                        //   icon: FontAwesomeIcons.fileLines,
-                        //   color: Color(0xff348FE2),
-                        //   secondaryColor: Color(0xff1F5788),
-                        // ),
-                        // const StatisticsGridItem(
-                        //   title: 'CPARA',
-                        //   value: "10/20",
-                        //   icon: FontAwesomeIcons.fileLines,
-                        //   color: Color(0xff727DB6),
-                        //   secondaryColor: Color(0xff454A6D),
-                        // ),
-                        // const StatisticsGridItem(
-                        //   title: 'CPT',
-                        //   value: "10/20",
-                        //   icon: FontAwesomeIcons.fileLines,
-                        //   color: Color(0xff49B6D5),
-                        //   secondaryColor: Color(0xff2C6E80),
-                        // ),
-                        // const StatisticsGridItem(
-                        //   title: 'CLHIV',
-                        //   value: "10/20",
-                        //   icon: FontAwesomeIcons.heart,
-                        //   color: Color(0xff49B6D5),
-                        //   secondaryColor: Color(0xff2C6E80),
-                        // ),
+                        StatisticsGridItem(
+                          title: 'FORM 1A',
+                          value: "${dashData.unapprovedF1A}/${dashData.form1a}",
+                          icon: FontAwesomeIcons.fileLines,
+                          color: kPrimaryColor,
+                          secondaryColor: const Color(0xff0E6668),
+                        ),
+                        StatisticsGridItem(
+                          title: 'FORM 1B',
+                          value: "${dashData.unapprovedF1B}/${dashData.form1b}",
+                          icon: FontAwesomeIcons.fileLines,
+                          color: const Color(0xff348FE2),
+                          secondaryColor: const Color(0xff1F5788),
+                        ),
+                        StatisticsGridItem(
+                          title: 'CPARA',
+                          value: "${dashData.unapprovedCPR}/${dashData.cpara}",
+                          icon: FontAwesomeIcons.fileLines,
+                          color: const Color(0xff727DB6),
+                          secondaryColor: const Color(0xff454A6D),
+                        ),
+                        StatisticsGridItem(
+                          title: 'CPT',
+                          value: "${dashData.unapprovedCPT}/${dashData.cpt}",
+                          icon: FontAwesomeIcons.fileLines,
+                          color: const Color(0xff49B6D5),
+                          secondaryColor: const Color(0xff2C6E80),
+                        ),
+                        StatisticsGridItem(
+                          title: 'CLHIV',
+                          value: "${dashData.clhiv}",
+                          icon: FontAwesomeIcons.heart,
+                          color: const Color(0xff49B6D5),
+                          secondaryColor: const Color(0xff2C6E80),
+                        ),
                         StatisticsGridItem(
                           title: 'Org Unit Id',
                           value: dashData.orgUnitId.toString(),


### PR DESCRIPTION
This pull request updates the API URL to point to the development server and adds new fields to the SummaryDataModel class. These fields include unapproved, form1a, form1b, cpara, cpt, clhiv, unapprovedF1A, unapprovedF1B, unapprovedCPR, unapprovedCPT, unapprovedHRS, and unapprovedHMF.

No issues are fixed in this pull request.