### PR TITLE
Fix Upsert On Caseloads

### DIFF
--- a/lib/providers/db_provider.dart
+++ b/lib/providers/db_provider.dart
@@ -66,11 +66,12 @@ class LocalDb {
     const defaultTime = 'DATETIME DEFAULT CURRENT_TIMESTAMP';
     const intType = 'INTEGER';
     const intTypeNull = 'INTEGER NULL';
+    const unique = 'UNIQUE';
 
     await db.execute('''
       CREATE TABLE $caseloadTable (
         ${OvcFields.id} $idType,
-        ${OvcFields.cboID} $textType,
+        ${OvcFields.cboID} $textType $unique,
         ${OvcFields.ovcFirstName} $textType,
         ${OvcFields.ovcSurname} $textType,
         ${OvcFields.registationDate} $textType,
@@ -267,13 +268,9 @@ class LocalDb {
       final batch = db.batch();
 
       for (final caseLoadModel in caseLoadModelList) {
-        batch.update(
+        batch.insert(
           caseloadTable,
           caseLoadModel.toMap(),
-          where: 'ovc_cpims_id = ?',
-          // Provide a condition to specify which records to update
-          whereArgs: [caseLoadModel.cpimsId],
-          // Provide the ID of the record to update
           conflictAlgorithm: ConflictAlgorithm.replace,
         );
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1062,10 +1062,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
### Problem
Currently when we sync records from upstream after the initial launch of the app, we are unable to update records in the local db. 

### Solution
This PR makes the following changes:
- make the `ovc_cpims_id` unique to help us with upserts
- update the conflict algorithm to conflict replace.

This 2 changes allows us to create upsert records when the sync acion is triggered